### PR TITLE
fix: remove unnecessary flush and panic cause

### DIFF
--- a/go/transport_sse.go
+++ b/go/transport_sse.go
@@ -49,9 +49,6 @@ func (es *eventSourceTransport) send(upd *update) error {
 				ID:   strconv.FormatInt(upd.Version, 10),
 				Data: b,
 			})
-			if f, ok := es.w.(http.Flusher); ok {
-				f.Flush()
-			}
 			sent <- err
 		}
 	}()


### PR DESCRIPTION
I had some random panic in the project:
```
: panic: runtime error: invalid memory address or nil pointer dereference
: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x597766]
: goroutine 7185032 [running]:
: bufio.(*Writer).Flush(0x0, 0x0, 0x17284e0)
:         bufio/bufio.go:601 +0x26
: net/http.(*chunkWriter).flush(0xc000c2a120)
:         net/http/server.go:397 +0x3b
: net/http.(*response).Flush(0xc000c2a0e0)
:         net/http/server.go:1682 +0x47
: github.com/NYTimes/gziphandler.(*GzipResponseWriter).Flush(0xc000212690)
:         github.com/NYTimes/gziphandler@v1.1.1/gzip.go:264 +0x77
: github.com/jpillora/velox/go.(*eventSourceTransport).send.func1(0xc001d2e150, 0xc000f144c0, 0xc00023bf00, 0xfd, 0x100, 0xc001ad3620)
:         github.com/jpillora/velox@v0.4.0/go/transport_sse.go:53 +0x214
: created by github.com/jpillora/velox/go.(*eventSourceTransport).send
:         github.com/jpillora/velox@v0.4.0/go/transport_sse.go:46 +0x10d
```


I figured out the problem is that when the writer became unavailable, `eventsource.WriteEvent` returned an error, then the `Flush` call will just panic.

Also the Flush call is unnecessary, if no error occured, the Flush is called inside `WriteEvent`: 

https://github.com/jpillora/eventsource/blob/634b95a8faf97f826c567d13e64e934a0d6cf94e/eventsource.go#L45

So I simply remove the Flush call in this PR.