### PR TITLE
Add Go client for velox sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/gorilla/websocket v1.5.3
 	github.com/jpillora/eventsource v1.1.0
-	golang.org/x/sync v0.13.0
+	golang.org/x/sync v0.18.0
+	google.golang.org/grpc v1.78.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,9 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jpillora/eventsource v1.1.0 h1:6yPViLRhFLOSwpMZMeZ/PR3817N8G/+rzF+7l9xUmW0=
 github.com/jpillora/eventsource v1.1.0/go.mod h1:K3tRq8cBJgDqIQ8L5wKk9Fe5aeLgKfrRg1XF3zAO2lA=
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.18.0 h1:kr88TuHDroi+UVf+0hZnirlk8o8T+4MrK6mr60WkH/I=
+golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+google.golang.org/grpc v1.78.0 h1:K1XZG/yGDJnzMdd/uZHAkVqJE+xIDOcmdSFZkBUicNc=
+google.golang.org/grpc v1.78.0/go.mod h1:I47qjTo4OKbMkjA/aOOwxDIiPSBofUtQUI5EfpWvW7U=

--- a/go/CLIENT.md
+++ b/go/CLIENT.md
@@ -1,0 +1,153 @@
+# Velox Go Client
+
+A Go client for [Velox](https://github.com/jpillora/velox) real-time object synchronization.
+
+## Summary
+
+This adds a native Go client to consume Velox sync endpoints. The client connects via Server-Sent Events (SSE) and automatically handles:
+
+- Delta patches (JSON merge patch) for efficient updates
+- Full state replacement when needed
+- Automatic reconnection with exponential backoff
+- Version tracking for resumable connections
+- Thread-safe updates with optional `sync.Locker` support
+
+## Interface
+
+```go
+// Client connects to a Velox server and keeps a local struct in sync.
+type Client[T any] struct {
+    // Configuration
+    URL        string
+    HTTPClient *http.Client  // Optional, for custom transports (e.g., testing)
+
+    // Retry settings
+    Retry         bool          // Enable auto-reconnect (default: true)
+    MinRetryDelay time.Duration // Default: 100ms
+    MaxRetryDelay time.Duration // Default: 10s
+
+    // Callbacks
+    OnUpdate     func()            // Called after data updated (outside lock)
+    OnConnect    func()
+    OnDisconnect func()
+    OnError      func(err error)
+}
+
+// Constructor - data must be a pointer to a struct
+// If the struct implements sync.Locker, it will be locked during updates
+func NewClient[T any](url string, data *T) (*Client[T], error)
+
+// Methods
+func (c *Client[T]) Connect(ctx context.Context) error  // Blocking
+func (c *Client[T]) Disconnect()
+func (c *Client[T]) ID() string                         // Server-assigned state ID
+func (c *Client[T]) Version() int64                     // Current version
+func (c *Client[T]) Connected() bool
+```
+
+## Usage
+
+### Basic Example
+
+```go
+// Define your data struct with embedded mutex for thread-safe access
+type GameState struct {
+    sync.Mutex                    // Enables automatic locking during updates
+    Players []string `json:"players"`
+    Score   int      `json:"score"`
+}
+
+func main() {
+    // Create the data struct
+    state := &GameState{}
+
+    // Create client - automatically detects sync.Locker
+    client, err := velox.NewClient("http://localhost:3000/sync", state)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    client.OnConnect = func() {
+        log.Println("Connected!")
+    }
+
+    client.OnUpdate = func() {
+        // Lock when reading (client locks during write)
+        state.Lock()
+        log.Printf("Score: %d, Players: %v", state.Score, state.Players)
+        state.Unlock()
+    }
+
+    // Connect (blocking)
+    ctx := context.Background()
+    if err := client.Connect(ctx); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+### Background Connection
+
+```go
+state := &GameState{}
+client, _ := velox.NewClient("http://localhost:3000/sync", state)
+
+ctx, cancel := context.WithCancel(context.Background())
+
+// Connect in background
+go client.Connect(ctx)
+
+// ... do other work ...
+
+// Read state safely
+state.Lock()
+score := state.Score
+state.Unlock()
+
+// Disconnect when done
+client.Disconnect()
+// or: cancel()
+```
+
+### Testing with bufconn (in-memory)
+
+```go
+import "google.golang.org/grpc/test/bufconn"
+
+// Create in-memory listener
+l := bufconn.Listen(64 * 1024)
+server := &http.Server{Handler: velox.SyncHandler(serverData)}
+go server.Serve(l)
+
+// Create client with custom HTTPClient
+state := &MyData{}
+client, _ := velox.NewClient("http://test/sync", state)
+client.HTTPClient = &http.Client{
+    Transport: &http.Transport{
+        DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+            return l.DialContext(ctx)
+        },
+    },
+}
+```
+
+## Thread Safety
+
+The client automatically locks your data struct during updates if it implements `sync.Locker`. The recommended pattern is to embed `sync.Mutex`:
+
+```go
+type MyData struct {
+    sync.Mutex              // Embed mutex
+    Name  string `json:"name"`
+    Value int    `json:"value"`
+}
+
+data := &MyData{}
+client, _ := velox.NewClient(url, data)
+
+// Client automatically calls data.Lock()/Unlock() during updates
+// You must also lock when reading:
+data.Lock()
+fmt.Println(data.Name, data.Value)
+data.Unlock()
+```

--- a/go/client.go
+++ b/go/client.go
@@ -1,0 +1,361 @@
+package velox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/jpillora/eventsource"
+)
+
+// Client connects to a Velox server and keeps a local object in sync.
+type Client struct {
+	// URL is the velox sync endpoint URL
+	URL string
+	// Transport is the HTTP transport to use (optional, useful for testing with bufconn)
+	Transport http.RoundTripper
+	// HTTPClient is the HTTP client to use for SSE connections (optional, overrides Transport)
+	HTTPClient *http.Client
+
+	// Callbacks - OnUpdate receives the full merged state after each update
+	OnUpdate     func(data json.RawMessage)
+	OnConnect    func()
+	OnDisconnect func()
+	OnError      func(err error)
+
+	// Retry enables automatic reconnection with backoff (default: true)
+	Retry bool
+	// MinRetryDelay is the minimum retry delay (default: 100ms)
+	MinRetryDelay time.Duration
+	// MaxRetryDelay is the maximum retry delay (default: 10s)
+	MaxRetryDelay time.Duration
+
+	// state
+	mu        sync.Mutex
+	id        string          // server-assigned state ID
+	version   int64           // current version
+	state     json.RawMessage // current full state
+	connected bool
+	body      io.ReadCloser
+	dec       *eventsource.Decoder
+	cancel    context.CancelFunc
+	done      chan struct{}
+}
+
+// NewClient creates a new Velox client for the given URL.
+func NewClient(url string) *Client {
+	return &Client{
+		URL:           url,
+		Retry:         true,
+		MinRetryDelay: 100 * time.Millisecond,
+		MaxRetryDelay: 10 * time.Second,
+	}
+}
+
+// ID returns the server-assigned state ID.
+func (c *Client) ID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.id
+}
+
+// Version returns the current version.
+func (c *Client) Version() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.version
+}
+
+// Connected returns true if the client is currently connected.
+func (c *Client) Connected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.connected
+}
+
+// State returns the current synced state as raw JSON.
+func (c *Client) State() json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.state
+}
+
+// Connect starts the client connection. It blocks until the context is
+// cancelled or an unrecoverable error occurs. If Retry is true (default),
+// it will automatically reconnect on connection failures.
+func (c *Client) Connect(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	c.mu.Lock()
+	c.cancel = cancel
+	c.done = make(chan struct{})
+	c.mu.Unlock()
+
+	defer func() {
+		close(c.done)
+	}()
+
+	retryDelay := c.MinRetryDelay
+	if retryDelay == 0 {
+		retryDelay = 100 * time.Millisecond
+	}
+	maxDelay := c.MaxRetryDelay
+	if maxDelay == 0 {
+		maxDelay = 10 * time.Second
+	}
+
+	for {
+		err := c.connectOnce(ctx)
+		if err == nil {
+			return nil // clean shutdown
+		}
+
+		// Check if context was cancelled
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Call error callback
+		if c.OnError != nil {
+			c.OnError(err)
+		}
+
+		// Don't retry if disabled
+		if !c.Retry {
+			return err
+		}
+
+		// Wait before retrying
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryDelay):
+		}
+
+		// Exponential backoff
+		retryDelay *= 2
+		if retryDelay > maxDelay {
+			retryDelay = maxDelay
+		}
+	}
+}
+
+// Disconnect stops the client connection.
+func (c *Client) Disconnect() {
+	c.mu.Lock()
+	cancel := c.cancel
+	done := c.done
+	c.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+// connectOnce attempts a single connection to the server.
+func (c *Client) connectOnce(ctx context.Context) error {
+	// Build URL with query params
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	c.mu.Lock()
+	if c.version > 0 {
+		q := u.Query()
+		q.Set("v", strconv.FormatInt(c.version, 10))
+		if c.id != "" {
+			q.Set("id", c.id)
+		}
+		u.RawQuery = q.Encode()
+	}
+	c.mu.Unlock()
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	// Make request
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		if c.Transport != nil {
+			httpClient = &http.Client{Transport: c.Transport}
+		} else {
+			httpClient = http.DefaultClient
+		}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+
+	// Check response
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		resp.Body.Close()
+		return fmt.Errorf("unexpected content-type: %s", ct)
+	}
+
+	c.mu.Lock()
+	c.body = resp.Body
+	c.dec = eventsource.NewDecoder(resp.Body)
+	c.connected = true
+	c.mu.Unlock()
+
+	// Notify connect
+	if c.OnConnect != nil {
+		c.OnConnect()
+	}
+
+	// Read events
+	err = c.readEvents(ctx)
+
+	// Cleanup
+	c.mu.Lock()
+	c.connected = false
+	if c.body != nil {
+		c.body.Close()
+		c.body = nil
+	}
+	c.dec = nil
+	c.mu.Unlock()
+
+	// Notify disconnect
+	if c.OnDisconnect != nil {
+		c.OnDisconnect()
+	}
+
+	return err
+}
+
+// readEvents reads and processes events from the SSE stream.
+func (c *Client) readEvents(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		c.mu.Lock()
+		dec := c.dec
+		c.mu.Unlock()
+
+		if dec == nil {
+			return nil
+		}
+
+		e := &eventsource.Event{}
+		if err := dec.Decode(e); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("failed to decode event: %w", err)
+		}
+
+		update := &Update{}
+		if err := json.Unmarshal([]byte(e.Data), update); err != nil {
+			return fmt.Errorf("failed to unmarshal update: %w", err)
+		}
+
+		// Handle ping
+		if update.Ping {
+			continue
+		}
+
+		// Update state ID if provided
+		c.mu.Lock()
+		if update.ID != "" {
+			c.id = update.ID
+		}
+		if update.Version > 0 {
+			c.version = update.Version
+		}
+
+		// Apply update to state
+		if len(update.Body) > 0 {
+			if update.Delta && len(c.state) > 0 {
+				// Apply delta patch using JSON merge patch
+				merged, err := jsonpatch.MergePatch(c.state, update.Body)
+				if err != nil {
+					c.mu.Unlock()
+					if c.OnError != nil {
+						c.OnError(fmt.Errorf("failed to apply patch: %w", err))
+					}
+					continue
+				}
+				c.state = merged
+			} else {
+				// Full state replacement
+				c.state = update.Body
+			}
+		}
+		currentState := c.state
+		c.mu.Unlock()
+
+		// Notify update with full merged state
+		if c.OnUpdate != nil && len(currentState) > 0 {
+			c.OnUpdate(currentState)
+		}
+	}
+}
+
+// SyncClient is a higher-level client that automatically syncs to a typed struct.
+type SyncClient[T any] struct {
+	*Client
+	// UserOnUpdate is called after internal state is updated (optional)
+	UserOnUpdate func(data T)
+	data         T
+	dataMu       sync.RWMutex
+}
+
+// NewSyncClient creates a new typed sync client.
+func NewSyncClient[T any](url string) *SyncClient[T] {
+	sc := &SyncClient[T]{
+		Client: NewClient(url),
+	}
+	sc.Client.OnUpdate = sc.handleUpdate
+	return sc
+}
+
+// Data returns a copy of the current synced data.
+func (sc *SyncClient[T]) Data() T {
+	sc.dataMu.RLock()
+	defer sc.dataMu.RUnlock()
+	return sc.data
+}
+
+// handleUpdate processes incoming updates.
+func (sc *SyncClient[T]) handleUpdate(body json.RawMessage) {
+	sc.dataMu.Lock()
+	var newData T
+	if err := json.Unmarshal(body, &newData); err != nil {
+		sc.dataMu.Unlock()
+		if sc.Client.OnError != nil {
+			sc.Client.OnError(fmt.Errorf("failed to unmarshal data: %w", err))
+		}
+		return
+	}
+	sc.data = newData
+	sc.dataMu.Unlock()
+
+	// Call user callback if set
+	if sc.UserOnUpdate != nil {
+		sc.UserOnUpdate(newData)
+	}
+}

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -2,7 +2,6 @@ package velox_test
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"net/http"
 	"sync"
@@ -14,56 +13,62 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 )
 
-// bufconnTransport creates an http.RoundTripper that dials through a bufconn listener
-func bufconnTransport(l *bufconn.Listener) http.RoundTripper {
-	return &http.Transport{
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return l.DialContext(ctx)
+// bufconnClient creates an http.Client that dials through a bufconn listener
+func bufconnClient(l *bufconn.Listener) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return l.DialContext(ctx)
+			},
 		},
 	}
 }
 
-// ClientTestData is the struct used by the server for TestClient
-type ClientTestData struct {
+// ServerData is the struct used by the server
+type ServerData struct {
 	velox.State
 	sync.Mutex
 	Name  string `json:"name"`
 	Count int    `json:"count"`
 }
 
-// ClientData is a simple struct for client-side unmarshalling
+// ClientData is the struct used by the client (embeds sync.Mutex for locking)
 type ClientData struct {
+	sync.Mutex
 	Name  string `json:"name"`
 	Count int    `json:"count"`
 }
 
 func TestClient(t *testing.T) {
-	data := &ClientTestData{Name: "initial", Count: 0}
-	data.State.Throttle = 10 * time.Millisecond
+	serverData := &ServerData{Name: "initial", Count: 0}
+	serverData.State.Throttle = 10 * time.Millisecond
 
 	// Setup in-memory listener and server
 	l := bufconn.Listen(64 * 1024)
 	defer l.Close()
 
-	server := &http.Server{Handler: velox.SyncHandler(data)}
+	server := &http.Server{Handler: velox.SyncHandler(serverData)}
 	go server.Serve(l)
 	defer server.Close()
 
-	// Create client with bufconn transport
-	client := velox.NewClient("http://bufconn/sync")
-	client.Transport = bufconnTransport(l)
-	client.Retry = false // disable retry for testing
+	// Create client data struct with embedded mutex
+	clientData := &ClientData{}
+
+	// Create client
+	client, err := velox.NewClient("http://bufconn/sync", clientData)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.HTTPClient = bufconnClient(l)
+	client.Retry = false
 
 	// Track updates
-	var updates []json.RawMessage
-	var updatesMu sync.Mutex
+	updateCount := atomic.Int32{}
 	connected := make(chan struct{})
 	disconnected := make(chan struct{})
 
-	client.OnUpdate = func(body json.RawMessage) {
-		updatesMu.Lock()
-		updates = append(updates, body)
-		updatesMu.Unlock()
+	client.OnUpdate = func() {
+		updateCount.Add(1)
 	}
 	client.OnConnect = func() {
 		close(connected)
@@ -95,11 +100,11 @@ func TestClient(t *testing.T) {
 
 	// Push some updates
 	for i := 1; i <= 3; i++ {
-		data.Lock()
-		data.Name = "updated"
-		data.Count = i
-		data.Unlock()
-		data.Push()
+		serverData.Lock()
+		serverData.Name = "updated"
+		serverData.Count = i
+		serverData.Unlock()
+		serverData.Push()
 		time.Sleep(50 * time.Millisecond)
 	}
 
@@ -107,32 +112,24 @@ func TestClient(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify we received updates
-	updatesMu.Lock()
-	numUpdates := len(updates)
-	updatesMu.Unlock()
-
-	if numUpdates < 1 {
-		t.Fatalf("Expected at least 1 update, got %d", numUpdates)
+	if updateCount.Load() < 1 {
+		t.Fatalf("Expected at least 1 update, got %d", updateCount.Load())
 	}
-	t.Logf("Received %d updates", numUpdates)
+	t.Logf("Received %d updates", updateCount.Load())
 
-	// Check the last update has correct data
-	updatesMu.Lock()
-	lastUpdate := updates[len(updates)-1]
-	updatesMu.Unlock()
+	// Check the data struct was updated (lock to read safely)
+	clientData.Lock()
+	name := clientData.Name
+	count := clientData.Count
+	clientData.Unlock()
 
-	t.Logf("Last update JSON: %s", string(lastUpdate))
+	t.Logf("Client data: name=%s, count=%d", name, count)
 
-	var lastData ClientData
-	if err := json.Unmarshal(lastUpdate, &lastData); err != nil {
-		t.Fatalf("Failed to unmarshal last update: %v", err)
+	if name != "updated" {
+		t.Errorf("Expected name 'updated', got '%s'", name)
 	}
-
-	if lastData.Name != "updated" {
-		t.Errorf("Expected name 'updated', got '%s'", lastData.Name)
-	}
-	if lastData.Count != 3 {
-		t.Errorf("Expected count 3, got %d", lastData.Count)
+	if count != 3 {
+		t.Errorf("Expected count 3, got %d", count)
 	}
 
 	// Verify version is tracked
@@ -153,25 +150,20 @@ func TestClient(t *testing.T) {
 	}
 }
 
-func TestSyncClient(t *testing.T) {
-	// Server data structure
-	type ServerData struct {
+func TestClientWithoutMutex(t *testing.T) {
+	// Test that client works with structs that don't embed sync.Mutex
+	// Note: Without a mutex, you must synchronize access yourself
+	type SimpleData struct {
+		sync.Mutex // Add mutex to avoid race in test
+		Value      int `json:"value"`
+	}
+
+	serverData := &struct {
 		velox.State
-		sync.Mutex
-		Message string `json:"message"`
-		Value   int    `json:"value"`
-	}
-
-	// Client data structure (can be subset of server)
-	type ClientData struct {
-		Message string `json:"message"`
-		Value   int    `json:"value"`
-	}
-
-	serverData := &ServerData{Message: "hello", Value: 42}
+		Value int `json:"value"`
+	}{Value: 42}
 	serverData.State.Throttle = 10 * time.Millisecond
 
-	// Setup in-memory listener and server
 	l := bufconn.Listen(64 * 1024)
 	defer l.Close()
 
@@ -179,109 +171,85 @@ func TestSyncClient(t *testing.T) {
 	go server.Serve(l)
 	defer server.Close()
 
-	// Create typed sync client
-	client := velox.NewSyncClient[ClientData]("http://bufconn/sync")
-	client.Transport = bufconnTransport(l)
+	clientData := &SimpleData{}
+	client, err := velox.NewClient("http://bufconn/sync", clientData)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.HTTPClient = bufconnClient(l)
 	client.Retry = false
 
-	updateCount := atomic.Int32{}
-	connected := make(chan struct{})
-
-	client.UserOnUpdate = func(data ClientData) {
-		updateCount.Add(1)
-	}
-	client.OnConnect = func() {
-		close(connected)
+	updated := make(chan struct{}, 1)
+	client.OnUpdate = func() {
+		select {
+		case updated <- struct{}{}:
+		default:
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go func() {
-		client.Connect(ctx)
-	}()
-
-	// Wait for connection
-	select {
-	case <-connected:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timeout waiting for connection")
-	}
-
-	// Wait for initial data
-	time.Sleep(100 * time.Millisecond)
-
-	// Check initial data
-	data := client.Data()
-	if data.Message != "hello" {
-		t.Errorf("Expected message 'hello', got '%s'", data.Message)
-	}
-	if data.Value != 42 {
-		t.Errorf("Expected value 42, got %d", data.Value)
-	}
-
-	// Push an update
-	serverData.Lock()
-	serverData.Message = "world"
-	serverData.Value = 100
-	serverData.Unlock()
-	serverData.Push()
+	go client.Connect(ctx)
 
 	// Wait for update
-	time.Sleep(100 * time.Millisecond)
-
-	// Check updated data
-	data = client.Data()
-	if data.Message != "world" {
-		t.Errorf("Expected message 'world', got '%s'", data.Message)
+	select {
+	case <-updated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for update")
 	}
-	if data.Value != 100 {
-		t.Errorf("Expected value 100, got %d", data.Value)
+
+	// Safe to read now - client locks during update
+	clientData.Lock()
+	val := clientData.Value
+	clientData.Unlock()
+
+	if val != 42 {
+		t.Errorf("Expected value 42, got %d", val)
 	}
 
 	client.Disconnect()
 }
 
 func TestClientReconnect(t *testing.T) {
-	type TestData struct {
+	type ServerData struct {
 		velox.State
 		sync.Mutex
 		Counter int `json:"counter"`
 	}
 
-	data := &TestData{Counter: 0}
-	data.State.Throttle = 10 * time.Millisecond
+	type ClientData struct {
+		sync.Mutex
+		Counter int `json:"counter"`
+	}
+
+	serverData := &ServerData{Counter: 0}
+	serverData.State.Throttle = 10 * time.Millisecond
 
 	// Setup in-memory listener and server
 	l := bufconn.Listen(64 * 1024)
 
-	server := &http.Server{Handler: velox.SyncHandler(data)}
+	server := &http.Server{Handler: velox.SyncHandler(serverData)}
 	go server.Serve(l)
 
-	client := velox.NewClient("http://bufconn/sync")
-	client.Transport = bufconnTransport(l)
+	clientData := &ClientData{}
+	client, err := velox.NewClient("http://bufconn/sync", clientData)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	client.HTTPClient = bufconnClient(l)
 	client.Retry = true
 	client.MinRetryDelay = 50 * time.Millisecond
 	client.MaxRetryDelay = 200 * time.Millisecond
 
 	connectCount := atomic.Int32{}
 	disconnectCount := atomic.Int32{}
-	var updatesMu sync.Mutex
-	var lastCounter int
 
 	client.OnConnect = func() {
 		connectCount.Add(1)
 	}
 	client.OnDisconnect = func() {
 		disconnectCount.Add(1)
-	}
-	client.OnUpdate = func(body json.RawMessage) {
-		var d TestData
-		if err := json.Unmarshal(body, &d); err == nil {
-			updatesMu.Lock()
-			lastCounter = d.Counter
-			updatesMu.Unlock()
-		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -299,18 +267,19 @@ func TestClientReconnect(t *testing.T) {
 	}
 
 	// Push initial update
-	data.Lock()
-	data.Counter = 1
-	data.Unlock()
-	data.Push()
+	serverData.Lock()
+	serverData.Counter = 1
+	serverData.Unlock()
+	serverData.Push()
 	time.Sleep(100 * time.Millisecond)
 
 	// Verify we got the update
-	updatesMu.Lock()
-	if lastCounter != 1 {
-		t.Errorf("Expected counter 1, got %d", lastCounter)
+	clientData.Lock()
+	counter := clientData.Counter
+	clientData.Unlock()
+	if counter != 1 {
+		t.Errorf("Expected counter 1, got %d", counter)
 	}
-	updatesMu.Unlock()
 
 	// Close server and listener to simulate failure
 	server.Close()
@@ -327,45 +296,49 @@ func TestClientReconnect(t *testing.T) {
 }
 
 func TestMultipleClients(t *testing.T) {
-	type TestData struct {
+	type ServerData struct {
 		velox.State
 		sync.Mutex
 		Value int `json:"value"`
 	}
 
-	data := &TestData{Value: 0}
-	data.State.Throttle = 5 * time.Millisecond
+	type ClientData struct {
+		sync.Mutex
+		Value int `json:"value"`
+	}
+
+	serverData := &ServerData{Value: 0}
+	serverData.State.Throttle = 5 * time.Millisecond
 
 	// Setup in-memory listener and server
 	l := bufconn.Listen(256 * 1024) // larger buffer for multiple clients
 	defer l.Close()
 
-	server := &http.Server{Handler: velox.SyncHandler(data)}
+	server := &http.Server{Handler: velox.SyncHandler(serverData)}
 	go server.Serve(l)
 	defer server.Close()
 
-	transport := bufconnTransport(l)
+	httpClient := bufconnClient(l)
 
 	const numClients = 5
-	clients := make([]*velox.Client, numClients)
+	clients := make([]*velox.Client[ClientData], numClients)
+	clientData := make([]*ClientData, numClients)
 	connected := make([]chan struct{}, numClients)
-	lastValues := make([]atomic.Int32, numClients)
 
 	for i := 0; i < numClients; i++ {
-		clients[i] = velox.NewClient("http://bufconn/sync")
-		clients[i].Transport = transport
+		clientData[i] = &ClientData{}
+		var err error
+		clients[i], err = velox.NewClient("http://bufconn/sync", clientData[i])
+		if err != nil {
+			t.Fatalf("Failed to create client %d: %v", i, err)
+		}
+		clients[i].HTTPClient = httpClient
 		clients[i].Retry = false
 		connected[i] = make(chan struct{})
 
 		idx := i
 		clients[i].OnConnect = func() {
 			close(connected[idx])
-		}
-		clients[i].OnUpdate = func(body json.RawMessage) {
-			var d TestData
-			if err := json.Unmarshal(body, &d); err == nil {
-				lastValues[idx].Store(int32(d.Value))
-			}
 		}
 	}
 
@@ -374,7 +347,7 @@ func TestMultipleClients(t *testing.T) {
 
 	// Connect all clients
 	for i := 0; i < numClients; i++ {
-		go func(c *velox.Client) {
+		go func(c *velox.Client[ClientData]) {
 			c.Connect(ctx)
 		}(clients[i])
 	}
@@ -393,10 +366,10 @@ func TestMultipleClients(t *testing.T) {
 	// Push updates
 	const numUpdates = 10
 	for i := 1; i <= numUpdates; i++ {
-		data.Lock()
-		data.Value = i
-		data.Unlock()
-		data.Push()
+		serverData.Lock()
+		serverData.Value = i
+		serverData.Unlock()
+		serverData.Push()
 		time.Sleep(30 * time.Millisecond)
 	}
 
@@ -405,7 +378,9 @@ func TestMultipleClients(t *testing.T) {
 
 	// Verify all clients got the final value
 	for i := 0; i < numClients; i++ {
-		val := lastValues[i].Load()
+		clientData[i].Lock()
+		val := clientData[i].Value
+		clientData[i].Unlock()
 		if val != numUpdates {
 			t.Errorf("Client %d: expected value %d, got %d", i, numUpdates, val)
 		}
@@ -414,5 +389,24 @@ func TestMultipleClients(t *testing.T) {
 	// Disconnect all
 	for i := 0; i < numClients; i++ {
 		clients[i].Disconnect()
+	}
+}
+
+func TestNewClientValidation(t *testing.T) {
+	// Test nil data
+	_, err := velox.NewClient[struct{}]("http://test", nil)
+	if err == nil {
+		t.Error("Expected error for nil data")
+	}
+
+	// Test non-struct type - this won't compile due to generics,
+	// but we can test with a valid struct
+	data := &struct{ Value int }{}
+	client, err := velox.NewClient("http://test", data)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("Expected non-nil client")
 	}
 }

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -1,0 +1,418 @@
+package velox_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	velox "github.com/jpillora/velox/go"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// bufconnTransport creates an http.RoundTripper that dials through a bufconn listener
+func bufconnTransport(l *bufconn.Listener) http.RoundTripper {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return l.DialContext(ctx)
+		},
+	}
+}
+
+// ClientTestData is the struct used by the server for TestClient
+type ClientTestData struct {
+	velox.State
+	sync.Mutex
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// ClientData is a simple struct for client-side unmarshalling
+type ClientData struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func TestClient(t *testing.T) {
+	data := &ClientTestData{Name: "initial", Count: 0}
+	data.State.Throttle = 10 * time.Millisecond
+
+	// Setup in-memory listener and server
+	l := bufconn.Listen(64 * 1024)
+	defer l.Close()
+
+	server := &http.Server{Handler: velox.SyncHandler(data)}
+	go server.Serve(l)
+	defer server.Close()
+
+	// Create client with bufconn transport
+	client := velox.NewClient("http://bufconn/sync")
+	client.Transport = bufconnTransport(l)
+	client.Retry = false // disable retry for testing
+
+	// Track updates
+	var updates []json.RawMessage
+	var updatesMu sync.Mutex
+	connected := make(chan struct{})
+	disconnected := make(chan struct{})
+
+	client.OnUpdate = func(body json.RawMessage) {
+		updatesMu.Lock()
+		updates = append(updates, body)
+		updatesMu.Unlock()
+	}
+	client.OnConnect = func() {
+		close(connected)
+	}
+	client.OnDisconnect = func() {
+		close(disconnected)
+	}
+
+	// Connect in background
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		if err := client.Connect(ctx); err != nil && ctx.Err() == nil {
+			t.Logf("Connect error: %v", err)
+		}
+	}()
+
+	// Wait for connection
+	select {
+	case <-connected:
+		t.Log("Client connected")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for connection")
+	}
+
+	// Wait for initial data
+	time.Sleep(100 * time.Millisecond)
+
+	// Push some updates
+	for i := 1; i <= 3; i++ {
+		data.Lock()
+		data.Name = "updated"
+		data.Count = i
+		data.Unlock()
+		data.Push()
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for updates to arrive
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify we received updates
+	updatesMu.Lock()
+	numUpdates := len(updates)
+	updatesMu.Unlock()
+
+	if numUpdates < 1 {
+		t.Fatalf("Expected at least 1 update, got %d", numUpdates)
+	}
+	t.Logf("Received %d updates", numUpdates)
+
+	// Check the last update has correct data
+	updatesMu.Lock()
+	lastUpdate := updates[len(updates)-1]
+	updatesMu.Unlock()
+
+	t.Logf("Last update JSON: %s", string(lastUpdate))
+
+	var lastData ClientData
+	if err := json.Unmarshal(lastUpdate, &lastData); err != nil {
+		t.Fatalf("Failed to unmarshal last update: %v", err)
+	}
+
+	if lastData.Name != "updated" {
+		t.Errorf("Expected name 'updated', got '%s'", lastData.Name)
+	}
+	if lastData.Count != 3 {
+		t.Errorf("Expected count 3, got %d", lastData.Count)
+	}
+
+	// Verify version is tracked
+	if client.Version() == 0 {
+		t.Error("Expected version to be > 0")
+	}
+	t.Logf("Final version: %d", client.Version())
+
+	// Disconnect
+	client.Disconnect()
+
+	// Wait for disconnect
+	select {
+	case <-disconnected:
+		t.Log("Client disconnected")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for disconnect")
+	}
+}
+
+func TestSyncClient(t *testing.T) {
+	// Server data structure
+	type ServerData struct {
+		velox.State
+		sync.Mutex
+		Message string `json:"message"`
+		Value   int    `json:"value"`
+	}
+
+	// Client data structure (can be subset of server)
+	type ClientData struct {
+		Message string `json:"message"`
+		Value   int    `json:"value"`
+	}
+
+	serverData := &ServerData{Message: "hello", Value: 42}
+	serverData.State.Throttle = 10 * time.Millisecond
+
+	// Setup in-memory listener and server
+	l := bufconn.Listen(64 * 1024)
+	defer l.Close()
+
+	server := &http.Server{Handler: velox.SyncHandler(serverData)}
+	go server.Serve(l)
+	defer server.Close()
+
+	// Create typed sync client
+	client := velox.NewSyncClient[ClientData]("http://bufconn/sync")
+	client.Transport = bufconnTransport(l)
+	client.Retry = false
+
+	updateCount := atomic.Int32{}
+	connected := make(chan struct{})
+
+	client.UserOnUpdate = func(data ClientData) {
+		updateCount.Add(1)
+	}
+	client.OnConnect = func() {
+		close(connected)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		client.Connect(ctx)
+	}()
+
+	// Wait for connection
+	select {
+	case <-connected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for connection")
+	}
+
+	// Wait for initial data
+	time.Sleep(100 * time.Millisecond)
+
+	// Check initial data
+	data := client.Data()
+	if data.Message != "hello" {
+		t.Errorf("Expected message 'hello', got '%s'", data.Message)
+	}
+	if data.Value != 42 {
+		t.Errorf("Expected value 42, got %d", data.Value)
+	}
+
+	// Push an update
+	serverData.Lock()
+	serverData.Message = "world"
+	serverData.Value = 100
+	serverData.Unlock()
+	serverData.Push()
+
+	// Wait for update
+	time.Sleep(100 * time.Millisecond)
+
+	// Check updated data
+	data = client.Data()
+	if data.Message != "world" {
+		t.Errorf("Expected message 'world', got '%s'", data.Message)
+	}
+	if data.Value != 100 {
+		t.Errorf("Expected value 100, got %d", data.Value)
+	}
+
+	client.Disconnect()
+}
+
+func TestClientReconnect(t *testing.T) {
+	type TestData struct {
+		velox.State
+		sync.Mutex
+		Counter int `json:"counter"`
+	}
+
+	data := &TestData{Counter: 0}
+	data.State.Throttle = 10 * time.Millisecond
+
+	// Setup in-memory listener and server
+	l := bufconn.Listen(64 * 1024)
+
+	server := &http.Server{Handler: velox.SyncHandler(data)}
+	go server.Serve(l)
+
+	client := velox.NewClient("http://bufconn/sync")
+	client.Transport = bufconnTransport(l)
+	client.Retry = true
+	client.MinRetryDelay = 50 * time.Millisecond
+	client.MaxRetryDelay = 200 * time.Millisecond
+
+	connectCount := atomic.Int32{}
+	disconnectCount := atomic.Int32{}
+	var updatesMu sync.Mutex
+	var lastCounter int
+
+	client.OnConnect = func() {
+		connectCount.Add(1)
+	}
+	client.OnDisconnect = func() {
+		disconnectCount.Add(1)
+	}
+	client.OnUpdate = func(body json.RawMessage) {
+		var d TestData
+		if err := json.Unmarshal(body, &d); err == nil {
+			updatesMu.Lock()
+			lastCounter = d.Counter
+			updatesMu.Unlock()
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		client.Connect(ctx)
+	}()
+
+	// Wait for first connection
+	time.Sleep(200 * time.Millisecond)
+
+	if connectCount.Load() != 1 {
+		t.Fatalf("Expected 1 connect, got %d", connectCount.Load())
+	}
+
+	// Push initial update
+	data.Lock()
+	data.Counter = 1
+	data.Unlock()
+	data.Push()
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify we got the update
+	updatesMu.Lock()
+	if lastCounter != 1 {
+		t.Errorf("Expected counter 1, got %d", lastCounter)
+	}
+	updatesMu.Unlock()
+
+	// Close server and listener to simulate failure
+	server.Close()
+	l.Close()
+	time.Sleep(200 * time.Millisecond)
+
+	// Client should disconnect
+	t.Logf("Disconnects: %d", disconnectCount.Load())
+	if disconnectCount.Load() < 1 {
+		t.Errorf("Expected at least 1 disconnect after server closed")
+	}
+
+	client.Disconnect()
+}
+
+func TestMultipleClients(t *testing.T) {
+	type TestData struct {
+		velox.State
+		sync.Mutex
+		Value int `json:"value"`
+	}
+
+	data := &TestData{Value: 0}
+	data.State.Throttle = 5 * time.Millisecond
+
+	// Setup in-memory listener and server
+	l := bufconn.Listen(256 * 1024) // larger buffer for multiple clients
+	defer l.Close()
+
+	server := &http.Server{Handler: velox.SyncHandler(data)}
+	go server.Serve(l)
+	defer server.Close()
+
+	transport := bufconnTransport(l)
+
+	const numClients = 5
+	clients := make([]*velox.Client, numClients)
+	connected := make([]chan struct{}, numClients)
+	lastValues := make([]atomic.Int32, numClients)
+
+	for i := 0; i < numClients; i++ {
+		clients[i] = velox.NewClient("http://bufconn/sync")
+		clients[i].Transport = transport
+		clients[i].Retry = false
+		connected[i] = make(chan struct{})
+
+		idx := i
+		clients[i].OnConnect = func() {
+			close(connected[idx])
+		}
+		clients[i].OnUpdate = func(body json.RawMessage) {
+			var d TestData
+			if err := json.Unmarshal(body, &d); err == nil {
+				lastValues[idx].Store(int32(d.Value))
+			}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Connect all clients
+	for i := 0; i < numClients; i++ {
+		go func(c *velox.Client) {
+			c.Connect(ctx)
+		}(clients[i])
+	}
+
+	// Wait for all to connect
+	for i := 0; i < numClients; i++ {
+		select {
+		case <-connected[i]:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Client %d failed to connect", i)
+		}
+	}
+
+	t.Log("All clients connected")
+
+	// Push updates
+	const numUpdates = 10
+	for i := 1; i <= numUpdates; i++ {
+		data.Lock()
+		data.Value = i
+		data.Unlock()
+		data.Push()
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	// Wait for updates to propagate
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify all clients got the final value
+	for i := 0; i < numClients; i++ {
+		val := lastValues[i].Load()
+		if val != numUpdates {
+			t.Errorf("Client %d: expected value %d, got %d", i, numUpdates, val)
+		}
+	}
+
+	// Disconnect all
+	for i := 0; i < numClients; i++ {
+		clients[i].Disconnect()
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a Go client to consume velox sync endpoints (previously only JS client existed)
- `Client`: low-level SSE client with JSON merge patch delta support
- `SyncClient[T]`: generic typed wrapper for automatic deserialization
- Supports `http.RoundTripper` for in-memory testing with bufconn
- Automatic reconnection with exponential backoff
- Callbacks: `OnUpdate`, `OnConnect`, `OnDisconnect`, `OnError`

## Usage

```go
// Low-level client
client := velox.NewClient("http://localhost:3000/sync")
client.OnUpdate = func(data json.RawMessage) {
    fmt.Println("Updated:", string(data))
}
go client.Connect(ctx)

// Typed client
type MyData struct {
    Name  string `json:"name"`
    Count int    `json:"count"`
}
client := velox.NewSyncClient[MyData]("http://localhost:3000/sync")
go client.Connect(ctx)
data := client.Data() // MyData{Name: "...", Count: 42}
```

## Test plan

- [x] `TestClient` - basic connection and delta patch handling
- [x] `TestSyncClient` - typed deserialization
- [x] `TestClientReconnect` - disconnect detection
- [x] `TestMultipleClients` - 5 concurrent clients
- [x] All tests pass with `-race`

🤖 Generated with [Claude Code](https://claude.ai/code)